### PR TITLE
Remove the default_executable

### DIFF
--- a/scorm_cloud.gemspec
+++ b/scorm_cloud.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = ["scorm_cloud"]
-  s.default_executable = "bin/scorm_cloud"
   s.require_paths = ["lib"]
 
   s.add_dependency('multipart-post')


### PR DESCRIPTION
It was deprecated without replacement, and we don't actually use it
anyhow.